### PR TITLE
fix: harden map compression caches and chunks

### DIFF
--- a/CODEBASE_DOCUMENTATION.md
+++ b/CODEBASE_DOCUMENTATION.md
@@ -156,8 +156,8 @@ examples/fast-loading.ts - Optimized loading strategies
 
 ## File Conventions
 - Maps expected in: ./assets/map.json (default)
-- Cache files: ./<mapname>.<hash>.compressed.json
-- Chunk files: ./<mapname>.<hash>.chunks.bin
+- Cache files: ./<mapname>.<sha256-16>.<version>.compressed.json
+- Chunk files: ./<mapname>.<sha256-16>.<version>.chunks.bin (binary) or .chunks (Brotli JSON)
 - Config: ./assets/config/map-compression.yaml
 
 ## Workflow

--- a/README-ADVANCED.md
+++ b/README-ADVANCED.md
@@ -42,11 +42,11 @@ For maximum performance, generate chunks at build time:
 cd hytopia-map-compression
 npm install
 
-# Generate JSON chunks (HyFire8 compatible format)
+# Generate JSON chunks (Brotli-compressed JSON, HyFire8 compatible)
 npm run precompute assets/map.json assets/map.chunks
 
 # Generate binary chunks (custom ultra-fast format)
-npm run precompute assets/map.json assets/map.bin -- --format=binary
+npm run precompute assets/map.json assets/map.chunks.bin -- --format=binary
 
 # Verify the output
 npm run precompute assets/map.json assets/map.chunks -- --verify
@@ -70,7 +70,7 @@ const world = await PrecomputeChunks.loadPrecomputedChunks('map.chunks');
 ## Chunk Formats
 
 ### JSON Chunks Format
-Compatible with HyFire8, uses Brotli compression:
+Brotli-compressed JSON (compatible with HyFire8) that expands to:
 ```json
 {
   "version": 1,
@@ -91,10 +91,14 @@ Compatible with HyFire8, uses Brotli compression:
 }
 ```
 
-### Binary Chunks Format
+### Binary Chunks Format (v1)
 Custom format optimized for speed:
 ```
-[chunkX:i32][chunkZ:i32][block1.x:i32][block1.y:i32][block1.z:i32][block1.id:u16]...
+[magic:u32][chunkCount:u32]
+repeat chunkCount:
+  [chunkX:i32][chunkY:i32][chunkZ:i32][blockCount:u32]
+  repeat blockCount:
+    [blockX:i32][blockY:i32][blockZ:i32][blockId:u16]
 ```
 
 ## Integration Examples

--- a/README.md
+++ b/README.md
@@ -40,17 +40,18 @@ The plugin uses **automatic optimization** with **hash-based caching**:
 
 ```
 First Run:    Original Map → Create BOTH Caches → Load (2s)
-              ├─ map.<hash>.compressed.json (99.5% smaller)
-              └─ map.<hash>.chunks.bin (pre-computed for ultra-fast loading)
+              ├─ map.<hash>.v<version>.compressed.json (99.5% smaller)
+              └─ map.<hash>.v<version>.chunks.bin (binary) or .chunks (Brotli JSON)
 
 Next Runs:    Load from Chunks → 50x Faster (40ms) ⚡
 
 Map Changed?: New Hash → Create New Caches → Auto-cleanup Old Files
 ```
 
-Cache files include the map's hash:
-- `map.a1b2c3d4.compressed.json` - Compressed version
-- `map.a1b2c3d4.chunks.bin` - Pre-computed chunks
+Cache files include the map's SHA-256 hash (16 chars) and plugin version tag:
+- `map.a1b2c3d4e5f6a7b8.v0_1_0.compressed.json` - Compressed version
+- `map.a1b2c3d4e5f6a7b8.v0_1_0.chunks.bin` - Binary pre-computed chunks
+- `map.a1b2c3d4e5f6a7b8.v0_1_0.chunks` - Brotli-compressed JSON chunks
 
 When your map changes, new cache files are created and old ones are cleaned up!
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@ export interface MapCompressionOptions {
   
   compression?: {
     algorithm?: 'brotli' | 'gzip' | 'none';
-    level?: number; // 1-9
+    level?: number; // 0-11
     chunkSize?: number;
     useDelta?: boolean;
     useVarint?: boolean;

--- a/src/utils/ConfigLoader.ts
+++ b/src/utils/ConfigLoader.ts
@@ -68,7 +68,7 @@ export class ConfigLoader {
       paths: config.paths,
       autoLoad: config.autoLoad,
       debug: config.logging?.enabled || false,
-      metrics: config.logging?.metrics || true,
+      metrics: config.logging?.metrics ?? true,
       logger: config.logging?.enabled ? console.log : undefined
     };
   }
@@ -104,7 +104,7 @@ export class ConfigLoader {
       autoLoad: options.autoLoad,
       logging: {
         enabled: options.debug || false,
-        metrics: options.metrics || true,
+        metrics: options.metrics ?? true,
         level: 'info'
       }
     };


### PR DESCRIPTION
## Summary
- fix cache metadata and hash consistency, and pull version from package.json
- make chunk caches more robust (supports .chunks, versioned binary format, and 3D chunk grouping)
- harden loaders: respect optimization flags, register block types, and improve map path loading
- update docs to reflect new cache naming and chunk formats

## Test plan
- Not run (per instructions)